### PR TITLE
스케쥴 생성시 오류 확인

### DIFF
--- a/backend/files/frontend/files/src/components/views/ScheduleDetail.vue
+++ b/backend/files/frontend/files/src/components/views/ScheduleDetail.vue
@@ -21,7 +21,7 @@
 
           :event-color="getEventColor"
           >
- 
+
         </v-calendar>
 
 
@@ -106,6 +106,7 @@
                 </v-col>
                 <v-col cols="8">
                   <v-file-input 
+                    :disabled="editedItem.id < 0"
                     label="select file to upload..."
                     filled
                     chips
@@ -117,6 +118,9 @@
                   </v-file-input>
                 </v-col>
                 <v-col cols="2">
+
+                  eid: {{ editedItem.eid }}
+                  id: {{ editedItem.id }}
                   <v-btn 
                     :disabled="!selectedFile"
                     color="blue"
@@ -426,13 +430,16 @@ module.exports = {
       
       editEvent({ nativeEvent, event }){
         console.log("editEvent");
+        console.log(`native event is`);
+        console.log(nativeEvent);
+        console.log(`event`);
         console.log(event);
         if(event.eid == undefined){
           this.changeEvent(event);
           return;
         }
         const open = () => {
-          this. isEdit = true;
+          this.isEdit = true;
           this.editedItem = event;
           this.selectedElement = nativeEvent.target;
           setTimeout(() => this.selectedOpen = true, 10)
@@ -456,22 +463,41 @@ module.exports = {
       },
       
       saveEvent(){
+
+        console.log(`--- save event button clicked ---`);
         this.selectedOpen = false
         if(!this.isEdit){  // newItem
+
+          console.log(`  request add new schedule. event:${this.editedItem.eid} schedule:${this.editedItem.id}`);
           apiService.addSchedule( Object.assign(this.editedItem,{color:this.color[this.currentEvent.belongs] }))
             .then(res => {
               this.editedItem = res.data;
               this.editedItem.resetContent
-              // console.log(res.data);
+
+              console.log(`  ---> received response for add new schedule `);
+              console.log(res.data);
+              console.log(` editedItem eid: ${this.editedItem.eid} id:${this.editedItem.id} `);
+              console.log(this.editedItem);
+
+              this.schedules.forEach(item =>{
+                console.log(`  *** schedule eid:${item.eid} id:${item.id}`);
+                if (item.id === -1) {
+                  item.id = res.data.id;
+                }
+              });
             }).catch(err =>{
               console.log(err);
               var index = this.schedules.indexOf(this.editedItem);
                   this.schedules.splice(index, 1);
             });
         }else{
+
+          console.log(`  request edit schedule. event:${this.editedItem.eid} schedule:${this.editedItem.id}`);
           apiService.updateSchedule( this.editedItem )
             .then(res => {
-                this.editedItem.resetContent
+
+              this.editedItem.resetContent
+              console.log(`  ---> received response for edit schedule `);
             }).catch(err =>{
               console.log(err);
               var index = this.schedules.indexOf(this.editedItem);

--- a/backend/files/server/controllers/schedule.js
+++ b/backend/files/server/controllers/schedule.js
@@ -21,6 +21,11 @@ function getAttachmentsFileList(eid, id) {
   let base_path = `frontend/files/uploads/schedule`;
   let target_dir_path = `${base_path}/${eid}_${id}`;
   const data = [];
+
+  if (!fs.existsSync(target_dir_path)) {
+    console.log(` attachments directory is not exist. eid:${eid} id:${id}`);
+    return data;
+  }
   const files = fs.readdirSync(target_dir_path);
   files.forEach(file => {
     console.log(` * filename : ${file}`);
@@ -133,7 +138,7 @@ module.exports = {
 
   upload(req, res) {
     console.log(`___schdule upload file___`);
-    console.log(req.files);
+    // console.log(req.files);
     console.log(req.body.eid);
     console.log(req.body.id);
 
@@ -155,8 +160,10 @@ module.exports = {
         }
       });
       data = getAttachmentsFileList(eid, id);
+      return res.status(200).send({ 'attachments': data });
     }
-    return res.status(200).send({ 'attachments': data });
+    
+    return res.status(500).send({ 'message': 'directory is not exist' });
   }, 
 
   attachments(req, res) {


### PR DESCRIPTION
* 스케쥴 생성시 정상적으로 backend로부터 새로 생성된 스케쥴 아이디를 받았음에도
캘린더의 해당 스케쥴의 아이디는 여전히 -1로 남아있는 현상 확인

따라서 새로 생성된 스케쥴에 파일을 첨부할 경우 이미지 저장 경로가 문제가 됨

이미지 저장 경로 : [이벤트아이디]-[스케쥴아이디]/첨부파일명

여기서 스케쥴아이디가 backend에서는 정상인데 frontend에서는 반영되기 이전인 -1이 되므로
경로가 불일치하게 됨

ex)
정상적인 경로는 /uploads/schedule/128_80/attachements.zip

현재 문제가 된 경로는 /uploads/schedule/128_-1/attachments.zip

브라우저를 새로고침 할경우 캘린더의 스케쥴 아이디는 정상적으로 변경됨

또 한가지 문제....
스케쥴이 생성되기 이전에는 첨부파일을 업로드 할 수 없도록 제한함. 
왜냐하면 "이벤트아이디-스케쥴아이디"가 바로 첨부파일의 저장 디렉터리 경로가 되므로, 
스케쥴아이디가 생성되지 않은 상태에서는 첨부파일을 저장할 수 없음. 
이 부분은 고민 좀 해봐야 함.
